### PR TITLE
slice_patterns feature is enabled.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Support for Unix domain socket clients and servers.
-#![feature(io, core, debug_builders, io_ext, convert)]
+#![feature(io, core, debug_builders, io_ext, convert, slice_patterns)]
 #![warn(missing_docs)]
 #![doc(html_root_url="https://sfackler.github.io/rust-unix-socket/doc")]
 


### PR DESCRIPTION
I am using this version of rustc. rustc 1.0.0-nightly (552080181 2015-03-27) (built 2015-03-28) slice_patterns feature should be enabled to compile rust-unix-socket.
