### PR TITLE
There is no std::ffi::AsOsStr anymore on Rust nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate libc;
 use debug_builders::DebugStruct;
 use std::convert::AsRef;
 use std::cmp::{self, Ordering};
-use std::ffi::{OsStr, AsOsStr};
+use std::ffi::OsStr;
 use std::io;
 use std::net::Shutdown;
 use std::iter::IntoIterator;


### PR DESCRIPTION
I have worked in
- removing std::ffi::AsOsStr
- It is compatible with 1.0.0-beta, 1.0.0-beta.2, nightly.
