### PR TITLE
added UnixSeqpacket and UnixSeqpacketListener. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["posix", "unix", "socket", "domain"]
 
 [dependencies]
-libc = "0.2.1"
+libc = "0.2.12"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
plus minor refactoring to consolidate into Inner.

This addresses issue https://github.com/rust-lang-nursery/unix-socket/issues/23 

This would be much nicer with generic impl specialization :) 

UnixStreamListener and UnixSeqpacketListener are 99% alike. In fact, in their implementations they only differ in 3 words, unfortunately, two of those are in return types, so there wasn't a clean way to factor them out, aside from making some sort of UnixSocket trait. So we're stuck with it unless we want to get crazy. 

I moved send and recv into Inner which cleaned up some code in UnixStream and UnixDatagram while reducing the amount to duplicate into UnixSeqpacket. 

Added a test for basic seqpacket functionality.  All of the rest of the tests still pass. 
