### PR TITLE
Updated libc to 0.2.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["posix", "unix", "socket", "domain"]
 
 [dependencies]
-libc = "0.2.1"
+libc = "0.2.20"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unix_socket"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Unix domain socket bindings"


### PR DESCRIPTION
I had some issues with using a recent version with nix and some other dependency, and I believe this was the culprit. This is a rather lazy pull request, but the tests did pass with the latest stable version of `libc`.