### PR TITLE
Fix for target: x86_64-linux-android

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,24 +691,14 @@ impl UnixListener {
     ///
     /// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
     /// ```
-    #[cfg(target_os="android")]
+
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         unsafe {
             let inner = try!(Inner::new(libc::SOCK_STREAM));
             let (addr, len) = try!(sockaddr_un(path));
-
+            #[cfg(target_os="android")]
             try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len as i32)));
-            try!(cvt(libc::listen(inner.0, 128)));
-
-            Ok(UnixListener { inner: inner })
-        }
-    }
-    #[cfg(not(target_os="android"))]
-    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
-        unsafe {
-            let inner = try!(Inner::new(libc::SOCK_STREAM));
-            let (addr, len) = try!(sockaddr_un(path));
-
+            #[cfg(not(target_os="android"))]
             try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len)));
             try!(cvt(libc::listen(inner.0, 128)));
 
@@ -941,23 +931,14 @@ impl UnixDatagram {
     ///
     /// let socket = UnixDatagram::bind("/path/to/my/socket").unwrap();
     /// ```
-    #[cfg(target_os="android")]
+
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
         unsafe {
             let inner = try!(Inner::new(libc::SOCK_DGRAM));
             let (addr, len) = try!(sockaddr_un(path));
-
+            #[cfg(target_os="android")]
             try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len as i32)));
-
-            Ok(UnixDatagram { inner: inner })
-        }
-    }
-    #[cfg(not(target_os="android"))]
-     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
-        unsafe {
-            let inner = try!(Inner::new(libc::SOCK_DGRAM));
-            let (addr, len) = try!(sockaddr_un(path));
-
+            #[cfg(not(target_os="android"))]
             try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len)));
 
             Ok(UnixDatagram { inner: inner })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,6 +691,19 @@ impl UnixListener {
     ///
     /// let listener = UnixListener::bind("/path/to/the/socket").unwrap();
     /// ```
+    #[cfg(target_os="android")]
+    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
+        unsafe {
+            let inner = try!(Inner::new(libc::SOCK_STREAM));
+            let (addr, len) = try!(sockaddr_un(path));
+
+            try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len as i32)));
+            try!(cvt(libc::listen(inner.0, 128)));
+
+            Ok(UnixListener { inner: inner })
+        }
+    }
+    #[cfg(not(target_os="android"))]
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         unsafe {
             let inner = try!(Inner::new(libc::SOCK_STREAM));
@@ -928,7 +941,19 @@ impl UnixDatagram {
     ///
     /// let socket = UnixDatagram::bind("/path/to/my/socket").unwrap();
     /// ```
+    #[cfg(target_os="android")]
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
+        unsafe {
+            let inner = try!(Inner::new(libc::SOCK_DGRAM));
+            let (addr, len) = try!(sockaddr_un(path));
+
+            try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len as i32)));
+
+            Ok(UnixDatagram { inner: inner })
+        }
+    }
+    #[cfg(not(target_os="android"))]
+     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
         unsafe {
             let inner = try!(Inner::new(libc::SOCK_DGRAM));
             let (addr, len) = try!(sockaddr_un(path));


### PR DESCRIPTION
When compiling my project for android x86_64, cargo complained when compiling unix-socket 0.5.0 with the following error:

```
error[E0308]: mismatched types
   --> /home/weisgerber/.cargo/registry/src/github.com-1ecc6299db9ec823/unix_socket-0.5.0/src/lib.rs:569:73
    |
569 |             try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len)));
    |                                                                         ^^^ expected i32, found u32

error[E0308]: mismatched types
   --> /home/weisgerber/.cargo/registry/src/github.com-1ecc6299db9ec823/unix_socket-0.5.0/src/lib.rs:719:73
    |
719 |             try!(cvt(libc::bind(inner.0, &addr as *const _ as *const _, len)));
    |                                                                         ^^^ expected i32, found u32

error: aborting due to 2 previous errors

error: Could not compile `unix_socket`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

I added code, to support this minor difference to androids socket implementation.

``` rust
#[cfg(target_os="android")]
(...)
#[cfg(not(target_os="android"))]
(...)
```

Target definition: `.cargo/config`:

```
[target.x86_64-linux-android]
ar = "toolchain/bin/x86_64-linux-android-ar"
linker = "toolchain/bin/x86_64-linux-android-clang"
```

The android toolchain i am using has been created with the following command [NDK: r16b]:

``` bash
android-ndk/build/tools/make_standalone_toolchain.py \
 --arch x86_64 \
 --api 24 \
 --stl=gnustl \
 --install-dir=.
```